### PR TITLE
Remove eval()

### DIFF
--- a/js/preventPastOrFutureDates.js
+++ b/js/preventPastOrFutureDates.js
@@ -246,7 +246,8 @@ function validate(ob, min, max, returntype, texttype, regexVal, returnFocus) {
 		}
 		
 		// Evaluate value with regex
-		eval('var regexVal2 = '+regexVal+';');
+		// Remove leading and trailing '/'
+		regexVal2 = new RegExp(regexVal.slice(1,-1)); 
 		if (regexVal2.test(ob.value))
 		{
 			// Passed the regex test!


### PR DESCRIPTION
Addresses submission feedback
> We are working on improving module submission standards, and are considering disallowing eval() calls in javascript.  The lone eval() call in this module looks like it can be implemented by executing the desired javascript directly instead.  Would you be able to implement that change, create a new tag for version 1.0.2We are working on improving module submission standards, and are considering disallowing eval() calls in javascript.  The lone eval() call in this module looks like it can be implemented by executing the desired javascript directly instead.  Would you be able to implement that change, create a new tag for version 1.0.2

