### PR TITLE
Decode html javascript side

### DIFF
--- a/js/preventPastOrFutureDates.js
+++ b/js/preventPastOrFutureDates.js
@@ -38,13 +38,19 @@
  * 
  *  Relevant thread: // https://community.projectredcap.org/questions/41383/use-datepicker-in-external-module-custom-code.html
  **/
+var decodeHtml = function(html) {
+    var txt = document.createElement("textarea");
+    txt.innerHTML = html;
+    return txt.value;
+}
+
 const reDates = /(\d{4}-\d{2}-\d{2}[^']*)/g;
 let isValidClick = false;
 
 $(document).ready(function () {
 	let module = ExternalModules['PreventPastOrFutureDates'].ExternalModule;
-	let preventFutureDateFields = JSON.parse(module.tt('preventFutureDateFields'));
-	let preventPastDateFields = JSON.parse(module.tt('preventPastDateFields'));
+	let preventFutureDateFields = JSON.parse(decodeHtml(module.tt('preventFutureDateFields')));
+	let preventPastDateFields = JSON.parse(decodeHtml(module.tt('preventPastDateFields')));
 	let attachedListeners = false;
 
 	// REDCap calls $.datepicker.setDefaults() after External Module javascript is executed.


### PR DESCRIPTION
Fix #6.

There is a bug in `ExternalModules::tt_transferToJS` that converts all applicable characters to HTML entities. Removing the call to `htmlentities` fixes the problem. The lines in question are:

```PHP
$key = json_encode(htmlentities($key, ENT_QUOTES));
$value = json_encode(htmlentities($value,  ENT_QUOTES));
```

While we wait for the [official fix](https://community.projectredcap.org/questions/126891/externalmodulestt-transfertojs-converts-all-html-e.html), decoding html entities javascript side fixes the issue. (https://stackoverflow.com/questions/7394748/whats-the-right-way-to-decode-a-string-that-has-special-html-entities-in-it/7394787#7394787)